### PR TITLE
Fix missing third-party submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,24 @@
+[submodule "third_party/dqc"]
+	path = third_party/dqc
+	url = https://github.com/ColinQiyangLi/dqc.git
+[submodule "third_party/FlowCPS"]
+	path = third_party/FlowCPS
+	url = https://github.com/IamCreateAI/FlowCPS.git
+[submodule "third_party/flow_grpo"]
+	path = third_party/flow_grpo
+	url = https://github.com/yifan123/flow_grpo.git
+[submodule "third_party/MAC"]
+	path = third_party/MAC
+	url = https://github.com/kwanyoungpark/MAC.git
+[submodule "third_party/qam"]
+	path = third_party/qam
+	url = https://github.com/ColinQiyangLi/qam.git
+[submodule "third_party/qc"]
+	path = third_party/qc
+	url = https://github.com/ColinQiyangLi/qc.git
+[submodule "third_party/r3m"]
+	path = third_party/r3m
+	url = https://github.com/facebookresearch/r3m.git
 [submodule "third_party/rl100-state"]
 	path = third_party/rl100-state
 	url = git@github.com:Lei-Kun/rl100-state.git


### PR DESCRIPTION
## Summary
- add missing `.gitmodules` entries for public third-party gitlink submodules
- use public HTTPS GitHub URLs for dqc, FlowCPS, flow_grpo, MAC, qam, qc, and r3m
- keep existing rl100-state SSH URL unchanged

## Verification
- `git config --file .gitmodules --get-regexp ^submodule\.`
- `git submodule update --init` succeeds for the public submodules at the recorded commits

## Notes
The existing tree already contains gitlink entries for these paths, but `.gitmodules` only listed `third_party/rl100-state`, so fresh clones could not initialize the public third-party submodules.